### PR TITLE
refactor guardianship form, saga, details

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -90,17 +90,14 @@ function App() {
             path='/service_partner/:partnerId'>
             <ServicePartnerProfile />
           </ProtectedRoute>
-          
-          <ProtectedRoute 
-          exact path='/guardianship/edit/:partnerId'>
+
+          <ProtectedRoute exact path='/guardianship/edit/:guardianshipId'>
             <GuardianshipDetails />
           </ProtectedRoute>
 
-          <ProtectedRoute 
-          exact path='/guardianship/:partnerId/:intakeId'>
+          <ProtectedRoute exact path='/guardianship/:partnerId/:intakeId'>
             <GuardianshipPage />
           </ProtectedRoute>
-
 
           <Route exact path='/login'>
             {user.id ? (

--- a/src/components/Guardianship/GuardianshipDetails.jsx
+++ b/src/components/Guardianship/GuardianshipDetails.jsx
@@ -5,37 +5,41 @@ import { useSelector } from 'react-redux';
 import GuardianshipForm from './GuardianshipForm';
 
 function GuardianshipDetails() {
-    const history = useHistory();
-    const { guardianshipId } = useParams();
-    console.log(`${guardianshipId} id page`);
-    const guardianships = useSelector((store) => store.guardianships);
-    console.log('Guardianship Details', guardianships);
-    const guardianship = guardianships.find(
-        (guardianship) => Number(guardianship.guardianship_id) === Number(guardianshipId)
-    );
-    console.log(`Profile Page for ${guardianship?.guardianship_id}`);
+  const history = useHistory();
+  const { guardianshipId } = useParams();
+  console.log(`${guardianshipId} id page`);
+  const guardianships = useSelector((store) => store.guardianships);
+  console.log('Guardianship Details', guardianships);
+  const guardianship = guardianships.find(
+    (guardianship) =>
+      Number(guardianship.guardianship_id) === Number(guardianshipId)
+  );
+  console.log(`Profile Page for ${guardianship?.guardianship_id}`);
 
-    // useEffect(() => {
-    //   console.log('load the profile page');
-    // }, []);
+  // useEffect(() => {
+  //   console.log('load the profile page');
+  // }, []);
 
-    return (
-        <div>
-            <p>Edit Guardiaship Form {guardianship?.guardianship_id}</p>
-            <button onClick={() => history.push('/service_partner')}>
-                Back to Service Partners
-            </button>
-            <p> Profile {guardianship?.guardianship_id}</p>
-            <GuardianshipForm guardianship={guardianship} partnerId= {undefined} intakeId={undefined} />
-            <hr />
-            <div>
-            {/* <button onClick={() => console.log(`Update Guardianship Form ${guardianship?.guardianship_id}`)}>
+  return (
+    <div>
+      <p>Edit Guardiaship Form {guardianship?.guardianship_id}</p>
+      <button onClick={() => history.push('/service_partner')}>
+        Back to Service Partners
+      </button>
+      <p> Profile {guardianship?.guardianship_id}</p>
+      <GuardianshipForm
+        guardianship={guardianship}
+        partnerId={undefined}
+        intakeId={undefined}
+      />
+      <hr />
+      <div>
+        {/* <button onClick={() => console.log(`Update Guardianship Form ${guardianship?.guardianship_id}`)}>
                     Update {guardianship?.guardianship_id}
                 </button> */}
-                
-            </div>
-        </div>
-    );
+      </div>
+    </div>
+  );
 }
 
 export default GuardianshipDetails;

--- a/src/components/Guardianship/GuardianshipForm.jsx
+++ b/src/components/Guardianship/GuardianshipForm.jsx
@@ -2,77 +2,99 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { dateStrip } from '../../utils/helper';
 
-
 function GuardianshipForm({ guardianship, partnerId, intakeId }) {
-    const dispatch = useDispatch();
-    console.log(partnerId, intakeId);
-    const initialGuardianship = {
-        courtOrderNumber: guardianship?.court_order_number ?? '',
-        cpsWorkerName: guardianship?.cps_worker_name ?? '',
-        cpsWorkerPhone: guardianship?.cps_worker_phone ?? '',
-        cpsWorkerEmail: guardianship?.cps_worker_email ?? '',
-        servicePartnerId: guardianship?.service_partner_id ?? partnerId,
-        formId: guardianship?.forms_aggregator_id ?? intakeId
-    };
-    const [guardianshipData, setGuardianshipData] = useState(initialGuardianship);
-    // const servicePartners = useSelector ( store => store.servicePartners )
+  const dispatch = useDispatch();
+  console.log(partnerId, intakeId);
+  const initialGuardianship = {
+    courtOrderNumber: guardianship?.court_order_number ?? '',
+    cpsWorkerName: guardianship?.cps_worker_name ?? '',
+    cpsWorkerPhone: guardianship?.cps_worker_phone ?? '',
+    cpsWorkerEmail: guardianship?.cps_worker_email ?? '',
+    servicePartnerId: guardianship?.service_partner_id ?? partnerId,
+    formId: guardianship?.forms_aggregator_id ?? intakeId,
+  };
+  const [guardianshipData, setGuardianshipData] = useState(initialGuardianship);
+  // const servicePartners = useSelector ( store => store.servicePartners )
 
-    const handleSubmit = (event) => {
-        event.preventDefault();
-        // dispatch saga
-        if (guardianship) {
-            dispatch({
-                type: 'UPDATE_GUARDIANSHIP',
-                payload: { ...guardianshipData, guardianship_id: guardianship.guardianship_id },
-            });
-        } else {
-            console.log('Creaeting a NEW Guardianship', guardianshipData );
-            dispatch({ type: 'CREATE_GUARDIANSHIP', payload: guardianshipData });
-            setGuardianshipData(initialGuardianship);
-            
-        }
-        alert(`${guardianshipData.servicePartnerId}'s Guardianship form to /guardianship`)
-    };
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    // dispatch saga
+    if (guardianship) {
+      dispatch({
+        type: 'UPDATE_GUARDIANSHIP',
+        payload: {
+          ...guardianshipData,
+          guardianshipId: guardianship.guardianship_id,
+        },
+      });
+    } else {
+      console.log('Creaeting a NEW Guardianship', guardianshipData);
+      dispatch({ type: 'CREATE_GUARDIANSHIP', payload: guardianshipData });
+      setGuardianshipData(initialGuardianship);
+    }
+    alert(
+      `${guardianshipData.servicePartnerId}'s Guardianship form to /guardianship`
+    );
+  };
 
-
-    return (
-        <div>
-            <h2>Guardianship Form</h2>
-            <form onSubmit={handleSubmit}>
-            <input
-                    required
-                    id="courtOrderNumber"
-                    type="text"
-                    placeholder="Court Order Number"
-                    value={guardianshipData.courtOrderNumber}
-                    onChange={(event) => setGuardianshipData({ ...guardianshipData, courtOrderNumber: event.target.value })}
-                />
-                <input
-                    required
-                    id="cpsWorkerName"
-                    type="text"
-                    placeholder="CPS Worker Name"
-                    value={guardianshipData.cpsWorkerName}
-                    onChange={(event) => setGuardianshipData({ ...guardianshipData, cpsWorkerName: event.target.value })}
-                />
-                <input
-                    required
-                    id="cpsWorkerPhone"
-                    type="text"
-                    placeholder="CPS Worker Phone"
-                    value={guardianshipData.cpsWorkerPhone}
-                    onChange={(event) => setGuardianshipData({ ...guardianshipData, cpsWorkerPhone: event.target.value })}
-                />
-                <input
-                    required
-                    id="cpsWorkerEmail"
-                    type="email"
-                    placeholder="CPS Worker Email"
-                    value={guardianshipData.cpsWorkerEmail}
-                    onChange={(event) => setGuardianshipData({ ...guardianshipData, cpsWorkerEmail: event.target.value })}
-                />
-                {/* This selector for Service partners will be useful at some point */}
-                {/* <select
+  return (
+    <div>
+      <h2>Guardianship Form</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          required
+          id='courtOrderNumber'
+          type='text'
+          placeholder='Court Order Number'
+          value={guardianshipData.courtOrderNumber}
+          onChange={(event) =>
+            setGuardianshipData({
+              ...guardianshipData,
+              courtOrderNumber: event.target.value,
+            })
+          }
+        />
+        <input
+          required
+          id='cpsWorkerName'
+          type='text'
+          placeholder='CPS Worker Name'
+          value={guardianshipData.cpsWorkerName}
+          onChange={(event) =>
+            setGuardianshipData({
+              ...guardianshipData,
+              cpsWorkerName: event.target.value,
+            })
+          }
+        />
+        <input
+          required
+          id='cpsWorkerPhone'
+          type='text'
+          placeholder='CPS Worker Phone'
+          value={guardianshipData.cpsWorkerPhone}
+          onChange={(event) =>
+            setGuardianshipData({
+              ...guardianshipData,
+              cpsWorkerPhone: event.target.value,
+            })
+          }
+        />
+        <input
+          required
+          id='cpsWorkerEmail'
+          type='email'
+          placeholder='CPS Worker Email'
+          value={guardianshipData.cpsWorkerEmail}
+          onChange={(event) =>
+            setGuardianshipData({
+              ...guardianshipData,
+              cpsWorkerEmail: event.target.value,
+            })
+          }
+        />
+        {/* This selector for Service partners will be useful at some point */}
+        {/* <select
                     required
                     id="servicePartnerId"
                     value={guardianshipData.servicePartnerId}
@@ -85,11 +107,11 @@ function GuardianshipForm({ guardianship, partnerId, intakeId }) {
                         </option>
                     ))}
                 </select> */}
-                
-                <button type="submit">{guardianship ? 'Update' : 'Create'}</button>
-            </form>
-        </div>
-    );
+
+        <button type='submit'>{guardianship ? 'Update' : 'Create'}</button>
+      </form>
+    </div>
+  );
 }
 
 export default GuardianshipForm;

--- a/src/redux/sagas/guardianship.saga.js
+++ b/src/redux/sagas/guardianship.saga.js
@@ -2,49 +2,53 @@ import axios from 'axios';
 import { put, takeEvery, takeLatest } from 'redux-saga/effects';
 
 function* fetchGuardianship(action) {
-    try {
-        
-        const response = yield axios.get(`/api/guardianship`);
-        console.log(response.data);
-        yield put({ type: 'SET_GUARDIANSHIP', payload: response.data });
-    } catch (error) {
-        console.log('Guardianship GET request failed', error);
-    }
+  try {
+    const response = yield axios.get(`/api/guardianship`);
+    console.log(response.data);
+    yield put({ type: 'SET_GUARDIANSHIP', payload: response.data });
+  } catch (error) {
+    console.log('Guardianship GET request failed', error);
+  }
 }
 
 function* createGuardianship(action) {
-    try {
-        yield axios.post('/api/guardianship', action.payload);
-        yield put({ type: 'FETCH_GUARDIANSHIP'});
-    } catch (error) {
-        console.log('Guardianship post request failed', error);
-    }
+  try {
+    yield axios.post('/api/guardianship', action.payload);
+    yield put({ type: 'FETCH_GUARDIANSHIP' });
+  } catch (error) {
+    console.log('Guardianship post request failed', error);
+  }
 }
 
 function* updateGuardianship(action) {
-    try {
-        yield axios.put(`/api/guardianship/${action.payload.guardianshipId}`, action.payload);
-        yield put({ type: 'FETCH_GUARDIANSHIP', payload: { userId: action.payload.userId } });
-    } catch (error) {
-        console.log('Guardianship update request failed', error);
-    }
+  try {
+    yield axios.put(
+      `/api/guardianship/${action.payload.guardianshipId}`,
+      action.payload
+    );
+    yield put({
+      type: 'FETCH_GUARDIANSHIP',
+      payload: { userId: action.payload.userId },
+    });
+  } catch (error) {
+    console.log('Guardianship update request failed', error);
+  }
 }
 
 function* deleteGuardianship(action) {
-    try {
-        yield axios.delete(`/api/guardianship/${action.payload}`);
-        yield put({ type: 'FETCH_GUARDIANSHIP' });
-    } catch (error) {
-        console.log('Guardianship delete request failed', error);
-    }
+  try {
+    yield axios.delete(`/api/guardianship/${action.payload}`);
+    yield put({ type: 'FETCH_GUARDIANSHIP' });
+  } catch (error) {
+    console.log('Guardianship delete request failed', error);
+  }
 }
 
-
 function* guardianshipSaga() {
-    yield takeEvery('FETCH_GUARDIANSHIP', fetchGuardianship);
-    yield takeLatest('CREATE_GUARDIANSHIP', createGuardianship);
-    yield takeLatest('UPDATE_GUARDIANSHIP', updateGuardianship);
-    yield takeLatest('DELETE_GUARDIANSHIP', deleteGuardianship);
+  yield takeEvery('FETCH_GUARDIANSHIP', fetchGuardianship);
+  yield takeLatest('CREATE_GUARDIANSHIP', createGuardianship);
+  yield takeLatest('UPDATE_GUARDIANSHIP', updateGuardianship);
+  yield takeLatest('DELETE_GUARDIANSHIP', deleteGuardianship);
 }
 
 export default guardianshipSaga;


### PR DESCRIPTION
Guardianship ID in the /guardianship/edit/:guardiansID

cleaned up the bug in the route that was preventing service partner specific guardianship information for pre-populating the the details on the edit(update) guardianship details screen.